### PR TITLE
Exit with an error if the job is interrupted

### DIFF
--- a/submit.go
+++ b/submit.go
@@ -197,10 +197,13 @@ func main() {
 	go func() {
 		job := Loop(client, job)
 		log.Printf("Job status is : %s", job.Status)
-		if job.Status == "COMPLETED" {
-			log.Printf("Job exit code : %v", job.ReturnCode)
+		log.Printf("Job exit code : %v", job.ReturnCode)
+		codeToReturn := job.ReturnCode
+		if job.Status == JobStatusTERMINATED || job.Status == JobStatusFAILED {
+			codeToReturn = 44
+			log.Printf("Job is finished, but not completely, fixed exit code : %v", codeToReturn)
 		}
-		returnCodeChan <- int(job.ReturnCode)
+		returnCodeChan <- int(codeToReturn)
 	}()
 
 	// return the channel to a value, and get the defer close channel

--- a/submit.go
+++ b/submit.go
@@ -71,6 +71,7 @@ type (
 		JobConfig              *string  `arg:"--job-conf"`
 		File                   string   `json:"file" ini:"file" arg:"positional"`
 		Parameters             []string `arg:"positional"`
+		NotCompletedExitCode   int64    `arg:"--not-completed-exit-code" help:"Exit code for TERMINATED and FAILED job, default is 0"`
 	}
 )
 
@@ -200,8 +201,8 @@ func main() {
 		log.Printf("Job exit code : %v", job.ReturnCode)
 		codeToReturn := job.ReturnCode
 		if job.Status == JobStatusTERMINATED || job.Status == JobStatusFAILED {
-			codeToReturn = 44
-			log.Printf("Job is finished, but not completely, fixed exit code : %v", codeToReturn)
+			codeToReturn = args.NotCompletedExitCode
+			log.Printf("Job is finished, but not completely, fixed exit code : %v", args.NotCompletedExitCode)
 		}
 		returnCodeChan <- int(codeToReturn)
 	}()

--- a/submit_test.go
+++ b/submit_test.go
@@ -238,7 +238,7 @@ func TestPrintLog(t *testing.T) {
 }
 
 func TestGetExitCodeCompletedJob(t *testing.T) {
-	notCompletedExitCode := int64(3)
+	interruptedJobExitCode := int64(3)
 
 	JobStatusStruct := &JobStatus{
 		ID:               "dummyId",
@@ -267,7 +267,7 @@ func TestGetExitCodeCompletedJob(t *testing.T) {
 
 	job, _ := client.Submit(ProjectID, jobSubmit)
 
-	returnedExitCode := getExitCode(job, notCompletedExitCode)
+	returnedExitCode := getExitCode(job, interruptedJobExitCode)
 	expectedExitCode := 1
 	if returnedExitCode != expectedExitCode {
 		t.Errorf("Returned exit code (%d) does not match expected exit code (%d)", returnedExitCode, expectedExitCode)
@@ -279,7 +279,7 @@ func TestGetExitCodeCompletedJob(t *testing.T) {
 }
 
 func TestGetExitCodeTerminatedJob(t *testing.T) {
-	notCompletedExitCode := int64(3)
+	interruptedJobExitCode := int64(3)
 
 	JobStatusStruct := &JobStatus{
 		ID:               "dummyId",
@@ -308,7 +308,7 @@ func TestGetExitCodeTerminatedJob(t *testing.T) {
 
 	job, _ := client.Submit(ProjectID, jobSubmit)
 
-	returnedExitCode := getExitCode(job, notCompletedExitCode)
+	returnedExitCode := getExitCode(job, interruptedJobExitCode)
 	expectedExitCode := 3
 
 	if returnedExitCode != expectedExitCode {


### PR DESCRIPTION
➡️ https://github.com/ovh/data-processing-spark-submit/pull/28

### 🩹 Problem
When a spark job fails with the status "_TERMINATED_" (when manually killed, for example) or "_FAILED_", the ovh-spark-submit returns 0, and Airflow interprets this output code as a success and starts further processing.

### 🤖 Proposal
The OVH API does not return an exit code for jobs with this status, and without this exit code the instance of the `JobStatus` struct uses the [zero-value](https://go.dev/ref/spec#The_zero_value) for the `ReturnCode`. An exit code of 0 is therefore returned. I propose to parameterize the desired exit code in the case of these two statuses with `--not-completed-exit-code NOT-COMPLETED-EXIT-CODE`.
