### PR TITLE
[FEATURE] Éviter les comportements zombie des jobs

### DIFF
--- a/data_processing.go
+++ b/data_processing.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"encoding/json"
 	"log"
 	"net/url"
 	"time"
@@ -64,6 +65,8 @@ type (
 		TTL              string                `json:"ttl"`
 		ReturnCode       int64                 `json:"returnCode"`
 	}
+	// Workaround
+	JobStatusArray []*JobStatus
 
 	// JobEngineParameter representation of JobEngineParameter in OVH API
 	JobEngineParameter struct {
@@ -108,7 +111,33 @@ func (c *Client) GetStatus(projectID string, jobID string) (*JobStatus, error) {
 
 	job := &JobStatus{}
 	path := fmt.Sprintf(DataProcessingStatus, url.QueryEscape(projectID), url.QueryEscape(jobID))
-	return job, c.OVH.Get(path, job)
+	err := c.OVH.Get(path, job)
+	if err != nil {
+		// Workaround because the OVH API can return an Array that is not decodable to
+		// JobStatus even though the response status is between 200 and 300 and the
+		// response is not empty.
+		// Prevents json: cannot unmarshal array into Go value of type main.JobStatus error.
+		if _, ok := err.(*json.UnmarshalTypeError); ok {
+			log.Printf("UnmarshalTypeError encountered: `%v`", err)
+			log.Printf("Unmarshal workaround triggered")
+			jobs := &JobStatusArray{}
+			err2 := c.OVH.Get(path, jobs)
+			if err2 != nil {
+				log.Printf("Unmarshal workaround failed with `%v`, skipping the workaround", err2)
+				return job, err
+			}
+			if len(*jobs) == 0 {
+				log.Printf("Unmarshal workaround result is empty, skipping the workaround")
+				return job, err
+			}
+			job2 := (*jobs)[0]
+			log.Printf("Unmarshal workaround works, only the first element of the array (of len %d) is retrieved: `%v`", len(*jobs), job2)
+			return job2, err2
+		} else {
+			log.Printf("Other error encountered: `%v`", err)
+		}
+	}
+	return job, err
 }
 
 // GetLog get log of the job from the API

--- a/data_processing_test.go
+++ b/data_processing_test.go
@@ -186,6 +186,101 @@ func TestGetStatus(t *testing.T) {
 
 }
 
+func TestGetStatusWorkaround(t *testing.T) {
+
+	engineParameter := []*JobEngineParameter{
+		{
+			Name:  "arguments",
+			Value: "1000, testargument",
+		},
+		{
+			Name:  "driver_cores",
+			Value: "2",
+		},
+		{
+			Name:  "driver_memory",
+			Value: "1",
+		},
+		{
+			Name:  "driver_memory_overhead",
+			Value: "512",
+		},
+		{
+			Name:  "executor_cores",
+			Value: "1",
+		},
+		{
+			Name:  "executor_num",
+			Value: "1",
+		},
+		{
+			Name:  "executor_memory",
+			Value: "2048",
+		},
+		{
+			Name:  "executor_memory_overhead",
+			Value: "512",
+		},
+		{
+			Name:  "main_application_code",
+			Value: "spark-examples.jar",
+		},
+		{
+			Name:  "main_class_name",
+			Value: "org.apache.spark.examples.SparkPi",
+		},
+		{
+			Name:  "job_type",
+			Value: "java",
+		},
+	}
+
+	jobStatus := &JobStatus{
+		ID:               JobID,
+		Name:             "hello",
+		Region:           "GRA",
+		Engine:           "spark",
+		ContainerName:    "ovh-odp",
+		CreationDate:     "2019-12-03T09:40:13Z",
+		StartDate:        "2019-12-03T09:40:15Z",
+		EndDate:          "",
+		EngineVersion:    "2.4.3",
+		EngineParameters: engineParameter,
+		Status:           "RUNNING",
+		ReturnCode:       '0',
+	}
+	jobStatusArray := []*JobStatus{jobStatus}
+
+	api_response, _ := json.Marshal(jobStatusArray)
+	// Init test
+	var InputRequest *http.Request
+	ts, ovh := initMockServer(&InputRequest, 200, string(api_response), nil, time.Duration(0))
+	defer ts.Close()
+
+	client := &Client{
+		OVH: ovh,
+	}
+
+	res, _ := client.GetStatus(ProjectID, JobID)
+	fmt.Printf("res: `%v`", res)
+
+	if res.StartDate != jobStatus.StartDate {
+		fmt.Println("coucou")
+		t.Fail()
+	}
+
+	if res.Name != jobStatus.Name {
+		fmt.Println("salut")
+		t.Fail()
+	}
+
+	if res.ReturnCode != jobStatus.ReturnCode {
+		fmt.Println("ciao")
+		t.Fail()
+	}
+
+}
+
 func TestKill(t *testing.T) {
 
 	// Init test


### PR DESCRIPTION
## 🌸 Problème

L'ovh-spark-submit n'arrive plus à récupérer le statut du job lancé et tourne à l'infini en loggant l'erreur `json: cannot unmarshal array into Go value of type main.JobStatus`.

## 🌳 Proposition

Créer un type JobStatusArray permettant d'unmarshal un array lorsque cette erreur survient.

## 🐝 Remarques

Nous ne savons pas pourquoi l'API retourne un Array. Le premier élément est considéré, sinon le contournement est ignoré. Le premier élément est potentiellement autre chose qu'un JobStatus, une erreur surgira alors, il faudra surveiller ce comportement, nous aurons alors plus d'information concernant cet Array mystère.

## 🤧 Pour tester

Lancer un job à partir de cette branche de l'ovh-spark-submit : 
```shell
go run . --interrupted-exit-code 44 --projectid PROJECT_ID --jobname local_metrics_KE_job --spark-version 3.5.0 --packages "org.postgresql:postgresql:42.7.3" --class fr.pix.data.metrics.IngestionMetricsJob --properties-file dev-application.properties --driver-cores 2 --driver-memory 4G --num-executors 4 --executor-cores 4 --executor-memory 10G s3a://"pix-data-spark-dev"/data-processing.jar ke
```

Malheureusement je en sais pas comment "créer" volontairement du zombïsme en lançant des jobs.

J'ai créé une pré-release https://github.com/1024pix/data-processing-spark-submit/releases/tag/v1.4.1-alpha qu'on pourra supprimer. Elle se base sur l'état actuel (14/05/25 16:33 https://github.com/1024pix/data-processing-spark-submit/pull/3/commits/5c88c23881f9b95423e15434271d6410213c4d7c) du code. Depuis airflow-integration j'ai modifié la variable `OVH_SPARK_SUBMIT_VERSION` de `v1.4.0` à `v1.4.1-alpha`. Puis j'ai lancé le DAG des ingestions. Les jobs sont passés, mais pas de logs liés au contournement. (J'ai repassé la variable à `v1.4.0` après)