### PR TITLE
[FEATURE] Debugger les comportements zombie des jobs

### DIFF
--- a/data_processing.go
+++ b/data_processing.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"encoding/json"
 	"log"
 	"net/url"
 	"time"
@@ -64,6 +65,8 @@ type (
 		TTL              string                `json:"ttl"`
 		ReturnCode       int64                 `json:"returnCode"`
 	}
+	// Workaround
+	stringArray []*string
 
 	// JobEngineParameter representation of JobEngineParameter in OVH API
 	JobEngineParameter struct {
@@ -108,7 +111,34 @@ func (c *Client) GetStatus(projectID string, jobID string) (*JobStatus, error) {
 
 	job := &JobStatus{}
 	path := fmt.Sprintf(DataProcessingStatus, url.QueryEscape(projectID), url.QueryEscape(jobID))
-	return job, c.OVH.Get(path, job)
+	err := c.OVH.Get(path, job)
+	log.Printf("Unmarshal debug retrieved result strings: `%v`", job)
+	if err != nil {
+		// Debug the API response because the OVH API can return an Array of String that is 
+		// not decodable to JobStatus even though the response status is between 200 and 300.
+		if _, ok := err.(*json.UnmarshalTypeError); ok {
+			log.Printf("UnmarshalTypeError encountered for API result: `%v`", job)
+			log.Printf("UnmarshalTypeError encountered: `%v`", err)
+			log.Printf("Unmarshal debug triggered")
+			apiResponse := &stringArray{}
+			err2 := c.OVH.Get(path, apiResponse)
+			var strs []string
+			for _, ptr := range *apiResponse {
+				if ptr != nil {
+					strs = append(strs, *ptr)
+				}
+			}
+			log.Printf("Unmarshal debug retrieved result strings: `%v`", strs)
+			if err2 != nil {
+				log.Printf("Unmarshal debug failed with `%v`", err2)
+				return job, err
+			}
+			return job, err
+		} else {
+			log.Printf("Other error encountered: `%v`", err)
+		}
+	}
+	return job, err
 }
 
 // GetLog get log of the job from the API

--- a/data_processing_test.go
+++ b/data_processing_test.go
@@ -186,6 +186,29 @@ func TestGetStatus(t *testing.T) {
 
 }
 
+func TestGetStatusDebug(t *testing.T) {
+	str := "dummy"
+	sa := stringArray{&str, &str}
+	api_response, _ := json.Marshal(sa)
+
+	// Init test
+	var InputRequest *http.Request
+	ts, ovh := initMockServer(&InputRequest, 200, string(api_response), nil, time.Duration(0))
+	defer ts.Close()
+
+	client := &Client{
+		OVH: ovh,
+	}
+
+	_, err := client.GetStatus(ProjectID, JobID)
+
+	if err != nil {
+		t.Logf("Expected fallback path to return original error, got: %v", err)
+	} else {
+		t.Fail()
+	}
+}
+
 func TestKill(t *testing.T) {
 
 	// Init test


### PR DESCRIPTION
## 🌸 Problème

L'ovh-spark-submit n'arrive plus à récupérer le statut du job lancé et tourne à l'infini en loggant l'erreur `json: cannot unmarshal array into Go value of type main.JobStatus`.

## 🌳 Proposition

Ajouter du debug pour comprendre ce qui est retourné par l'API OVH et qui n'est pas correctement décodé.

## 🐝 Remarques

Dans la PR #3 nous nous étions rendus compte que le résultat de l'API était un tableau de string. Cette PR ajoute le code nécessaire pour logger le contenu de ce tableau. Elle ne permet pas de solutionner le problème.

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
